### PR TITLE
add a style class for scroll box overflow shadowing named shadowbox. …

### DIFF
--- a/public/styles.css
+++ b/public/styles.css
@@ -116,6 +116,37 @@ header {
 	background-color: #fced05;
 }
 
+/*/////////// Scroll Shadow /////////*/
+.shadowbox {
+	overflow: auto;
+	width: 200px;
+	max-height: 200px;
+	margin: 50px auto;
+
+	background:
+		/* Shadow covers */
+		linear-gradient(#bec4d9 30%, rgba(255,255,255,0)),
+		linear-gradient(rgba(255,255,255,0), #bec4d9 70%) 0 100%,
+		
+		/* Shadows */
+		radial-gradient(50% 0, farthest-side, rgba(0,0,0,.2), rgba(0,0,0,0)),
+		radial-gradient(50% 100%,farthest-side, rgba(0,0,0,.2), rgba(0,0,0,0)) 0 100%;
+	background:
+		/* Shadow covers */
+		linear-gradient(#bec4d9 30%, rgba(255,255,255,0)),
+		linear-gradient(rgba(255,255,255,0), #bec4d9 70%) 0 100%,
+		
+		/* Shadows */
+		radial-gradient(farthest-side at 50% 0, rgba(0,0,0,.2), rgba(0,0,0,0)),
+		radial-gradient(farthest-side at 50% 100%, rgba(0,0,0,.2), rgba(0,0,0,0)) 0 100%;
+	background-repeat: no-repeat;
+	background-color: #bec4d9;
+	background-size: 100% 40px, 100% 40px, 100% 14px, 100% 14px;
+	
+	/* Opera doesn't support this in the shorthand */
+	background-attachment: local, local, scroll, scroll;
+}
+
 /*//////////Carousel/////////*/
 
 .carousel {

--- a/src/components/Content.jsx
+++ b/src/components/Content.jsx
@@ -12,7 +12,7 @@ function Content() {
 				</h2>
 				<SimpleSlider imgArray={aboutImg}/>
 				
-				<p className="content-paragraph">
+				<p className="content-paragraph shadowbox" >
 					Make the most of yourself and you are on a good path to make the most
 					of life. There's plenty of things I can tell you about myself, from
 					the diverse places I've lived, death, life, love. But you aren't going
@@ -42,7 +42,7 @@ function Content() {
 					adventure
 				</h2>
 				<SimpleSlider imgArray={adventureImg} />
-				<p className="content-paragraph">
+				<p className="content-paragraph shadowbox" >
 				Beauty, Adventure, Travel, and Excitement aren't just clichés. They all
 				represent pieces of the experience of life that I try to seek out in
 				the things I do. All the photos on this site are from the many
@@ -57,7 +57,7 @@ function Content() {
 					excitement
 				</h2>
 				<SimpleSlider imgArray={excitementImg} />
-				<p className="content-paragraph">
+				<p className="content-paragraph shadowbox">
 					Without some danger there isn't excitement. By simply paying attention
 					enough you can manage you experience safely through being prepared and
 					absorbing the stories of those who have gone before you. For me, I try
@@ -71,7 +71,7 @@ function Content() {
 					beauty
 				</h2>
 				<SimpleSlider imgArray={beautyImg} />
-				<p className="content-paragraph">
+				<p className="content-paragraph shadowbox">
 					Of course there's beauty to be found in everything if you look hard
 					enough, it is in the eye of the beholder and existing conventions, but
 					nothing compares to an in person experience. Finding a soul in the
@@ -89,7 +89,7 @@ function Content() {
 					travel
 				</h2>
 				<SimpleSlider imgArray={travelImg} />
-				<p className="content-paragraph">
+				<p className="content-paragraph shadowbox">
 					In my experience the best way to understand something different is to
 					try it in earnest. Having lived on four continents I can say, nothing
 					gives you full apperciation and knowledge unless you actually live the


### PR DESCRIPTION
… Seems to be working good though the only overflow is on the about paragraph in content.  It's an older CSS only solution using background.  I learned about it from https://lea.verou.me/2012/04/background-attachment-local/  This is also the real fix branch for the scroll overflow.  The other was mislabeled